### PR TITLE
Adjust installer line due to bug in ZF1

### DIFF
--- a/docker/image/console/root/lib/task/magento/install.sh
+++ b/docker/image/console/root/lib/task/magento/install.sh
@@ -20,6 +20,7 @@ function task_magento_install()
         --db_user '${DB_USER}' \
         --db_pass '${DB_PASS}' \
         --url 'https://${APP_HOST}/' \
+        --skip_url_validation 'yes' \
         --use_rewrites 'yes' \
         --use_secure 'yes' \
         --secure_base_url 'https://${APP_HOST}/' \


### PR DESCRIPTION
There is a bug in the ZF1 HTTP_Client library when validating requests which blocks the installer if validating the base url is enabled.