### PR TITLE
Add frontend build, detecting if package.json is available at a given path

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -68,6 +68,14 @@ services:
     networks:
       - private
       - shared
+  node:
+    build: docker/image/node
+{% if @('app.build') == 'dynamic' %}
+    volumes:
+      - {{ (dockersync) ? @('workspace.name') ~ '-sync:/app:nocopy' : '../:/app:delegated' }}
+{% endif %}
+    networks:
+      - private
   php-fpm:
     build: docker/image/php-fpm
 {% if @('app.build') == 'dynamic' %}

--- a/docker/image/node/Dockerfile
+++ b/docker/image/node/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:10-alpine
+
+RUN apk --update add \
+  # package dependencies \
+    autoconf \
+    automake \
+    file \
+    g++ \
+    gcc \
+    make \
+    nasm \
+    zlib-dev \
+  # clean \
+    && rm -rf /var/cache/apk/*

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -20,6 +20,9 @@ attributes.default:
       basic: ~
       github: ~
 
+  frontend:
+    path: /app
+
   magento:
     edition: enterprise
     version: 1.14.4.0

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -75,3 +75,18 @@ command('assets upload'):
   exec: |
     #!bash(workspace:/)|@
     passthru ws.aws s3 sync @('assets.local') @('assets.remote')
+
+command('frontend build'):
+  exec: |
+    #!bash(harness:/)|@
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && (test -f package.json || exit 0) && npm install && node_modules/.bin/gulp build'
+
+command('frontend watch'):
+  exec: |
+    #!bash(harness:/)|@
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && (test -f package.json || exit 0) && node_modules/.bin/gulp serve'
+
+command('frontend console'):
+  exec: |
+    #!bash(harness:/)|@
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path'); sh'

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -79,12 +79,12 @@ command('assets upload'):
 command('frontend build'):
   exec: |
     #!bash(harness:/)|@
-    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && (test -f package.json || exit 0) && npm install && node_modules/.bin/gulp build'
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && test -f package.json && npm install && node_modules/.bin/gulp build'
 
 command('frontend watch'):
   exec: |
     #!bash(harness:/)|@
-    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && (test -f package.json || exit 0) && node_modules/.bin/gulp serve'
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && test -f package.json && node_modules/.bin/gulp serve'
 
 command('frontend console'):
   exec: |

--- a/harness/scripts/enable.sh
+++ b/harness/scripts/enable.sh
@@ -15,6 +15,7 @@ if [ ! -f .flag-built ]; then
         passthru docker-compose -p "$NAMESPACE" build --no-cache console
         passthru docker-compose -p "$NAMESPACE" up -d console
         passthru docker-compose -p "$NAMESPACE" exec -T -u build console app init
+        passthru ws frontend build
         [[ "${APP_MODE}" = "production" ]] && passthru docker-compose -p "$NAMESPACE" exec -T -u build console app build pass-2
         passthru docker commit "${NAMESPACE}_console_1" "${NAMESPACE}_console:latest"
         passthru docker-compose -p "$NAMESPACE" build --no-cache nginx php-fpm
@@ -24,6 +25,7 @@ if [ ! -f .flag-built ]; then
         passthru docker-compose -p "$NAMESPACE" exec -T -u build console app build pass-1
         passthru docker-compose -p "$NAMESPACE" exec -T -u build console app build pass-2
         passthru docker-compose -p "$NAMESPACE" exec -T -u build console app init
+        passthru ws frontend build
     fi
 
     touch .flag-built


### PR DESCRIPTION
* Run the frontend build after the first pass of the build, in case dependencies are fetched via composer.
* Build handled by `ws` task, so they can be easily delegated to `workspace.yml` in the case of custom workflows