### PR TITLE
Better frontend checks for if package.json exists.

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -79,12 +79,12 @@ command('assets upload'):
 command('frontend build'):
   exec: |
     #!bash(harness:/)|@
-    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && test -f package.json && npm install && node_modules/.bin/gulp build'
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && if [ ! -f "package.json" ]; then exit 0; fi && npm install && node_modules/.bin/gulp build'
 
 command('frontend watch'):
   exec: |
     #!bash(harness:/)|@
-    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && test -f package.json && node_modules/.bin/gulp serve'
+    docker-compose -p @('namespace') run --rm -u node node sh -c 'cd @('frontend.path') && if [ ! -f "package.json" ]; then exit 0; fi && node_modules/.bin/gulp serve'
 
 command('frontend console'):
   exec: |


### PR DESCRIPTION
Currently if it doesn't exist the `ws frontend build` command will return an error and cancel the build.