### PR TITLE
Fix exit code for harness scripts if USE_DOCKER_SYNC is no

### DIFF
--- a/harness/scripts/disable.sh
+++ b/harness/scripts/disable.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-[[ "$USE_DOCKER_SYNC" = "yes" ]] && run docker-sync stop
+if [[ "$USE_DOCKER_SYNC" = "yes" ]]; then
+    run docker-sync stop
+fi
 run docker-compose -p "$NAMESPACE" stop

--- a/harness/scripts/enable.sh
+++ b/harness/scripts/enable.sh
@@ -36,5 +36,7 @@ else
 fi
 
 if [ "$APP_BUILD" = "dynamic" ]; then
-    [[ "$USE_DOCKER_SYNC" = "yes" ]] && passthru docker-sync start
+    if [[ "$USE_DOCKER_SYNC" = "yes" ]]; then
+        passthru docker-sync start
+    fi
 fi


### PR DESCRIPTION
Stops anything hooked onto `harness.installed` from working.