### PR TITLE
Fix multiple environments being load balanced

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -67,7 +67,6 @@ services:
       - php-fpm:php-fpm
     networks:
       - private
-      - monitoring
       - shared
   node:
     build: docker/image/node
@@ -95,7 +94,6 @@ services:
       - redis-session:redis-session
     networks:
       - private
-      - monitoring
       - shared
     environment:
       <<: *APP_ENV_VARS
@@ -121,7 +119,7 @@ services:
       - MYSQL_PASSWORD=${DB_PASS}
     networks:
       - private
-      - monitoring
+      - shared
   redis:
     image: redis:4-alpine
     labels:
@@ -129,7 +127,7 @@ services:
       - co.elastic.logs/module=redis
     networks:
       - private
-      - monitoring
+      - shared
   redis-session:
     image: redis:4-alpine
     labels:
@@ -137,13 +135,10 @@ services:
       - co.elastic.logs/module=redis
     networks:
       - private
-      - monitoring
+      - shared
 networks:
   private:
     external: false
-  monitoring:
-    external:
-      name: my127ws_monitoring
   shared:
     external:
       name: my127ws

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -9,14 +9,18 @@ services:
 {% endif %}
   chrome:
     build: docker/image/chrome
-    networks:
-      - shared
-      - private
     environment:
       HOST_OS_FAMILY: ${HOST_OS_FAMILY}
       APP_HOST: ${APP_HOST}
     labels:
       - traefik.enable=false
+    networks:
+      private:
+        aliases:
+          - chrome
+      shared:
+        aliases:
+          - {{ @('namespace') }}_chrome
   console:
 {% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.dynamic.sh
@@ -66,8 +70,15 @@ services:
     depends_on:
       - php-fpm
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - nginx
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_nginx
+      shared:
+        aliases:
+          - {{ @('namespace') }}_nginx
   node:
     build: docker/image/node
 {% if @('app.build') == 'dynamic' %}
@@ -86,8 +97,12 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - php-fpm
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_php-fpm
     depends_on:
       - console
     environment:
@@ -113,25 +128,42 @@ services:
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - mysql
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_mysql
   redis:
     image: redis:4-alpine
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis
     networks:
-      - private
+      private:
+        aliases:
+          - redis
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_redis
   redis-session:
     image: redis:4-alpine
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis
     networks:
-      - private
+      private:
+        aliases:
+          - redis-session
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_redis-session
 networks:
   private:
     external: false
+  monitoring:
+    external:
+      name: my127ws_monitoring
   shared:
     external:
       name: my127ws

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -15,12 +15,8 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      private:
-        aliases:
-          - chrome
-      shared:
-        aliases:
-          - {{ @('namespace') }}_chrome
+      - private
+      - shared
   console:
 {% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.dynamic.sh
@@ -47,13 +43,13 @@ services:
       DB_PASS: ${DB_PASS}
       DB_NAME: ${DB_NAME}
       DB_ROOT_PASS: ${DB_ROOT_PASS}
+    links:
+      - memcached:memcached
+      - mysql:mysql
+      - redis:redis
+      - redis-session:redis-session
     networks:
       - private
-    depends_on:
-      - memcached
-      - mysql
-      - redis
-      - redis-session
   nginx:
     build: docker/image/nginx
 {% if @('app.build') == 'dynamic' %}
@@ -67,18 +63,12 @@ services:
       - traefik.port=80
       - co.elastic.logs/module=nginx
       - co.elastic.metrics/module=nginx
-    depends_on:
-      - php-fpm
+    links:
+      - php-fpm:php-fpm
     networks:
-      private:
-        aliases:
-          - nginx
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_nginx
-      shared:
-        aliases:
-          - {{ @('namespace') }}_nginx
+      - private
+      - monitoring
+      - shared
   node:
     build: docker/image/node
 {% if @('app.build') == 'dynamic' %}
@@ -96,15 +86,17 @@ services:
 {% endif %}
     labels:
       - traefik.enable=false
-    networks:
-      private:
-        aliases:
-          - php-fpm
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_php-fpm
     depends_on:
       - console
+    links:
+      - memcached:memcached
+      - mysql:mysql
+      - redis:redis
+      - redis-session:redis-session
+    networks:
+      - private
+      - monitoring
+      - shared
     environment:
       <<: *APP_ENV_VARS
   memcached:
@@ -128,36 +120,24 @@ services:
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
     networks:
-      private:
-        aliases:
-          - mysql
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_mysql
+      - private
+      - monitoring
   redis:
     image: redis:4-alpine
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis
     networks:
-      private:
-        aliases:
-          - redis
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_redis
+      - private
+      - monitoring
   redis-session:
     image: redis:4-alpine
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis
     networks:
-      private:
-        aliases:
-          - redis-session
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_redis-session
+      - private
+      - monitoring
 networks:
   private:
     external: false

--- a/docker/image/console/root/lib/sidekick.sh
+++ b/docker/image/console/root/lib/sidekick.sh
@@ -33,14 +33,14 @@ prompt()
 
 run()
 {
+    local COMMAND="$*"
     if [ "$VERBOSE" = "no" ]; then
         prompt
 
-        echo "  > $*"
+        echo "  > ${COMMAND[*]}"
         setCommandIndicator $INDICATOR_RUNNING
-        bash -c "$@" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
 
-        if [ "$?" != "0" ]; then
+        if ! bash -c "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt; then
             setCommandIndicator $INDICATOR_ERROR
 
             cat /tmp/my127ws-stderr.txt
@@ -55,7 +55,7 @@ run()
             setCommandIndicator $INDICATOR_SUCCESS
         fi
     else
-        passthru "$@"
+        passthru "${COMMAND[@]}"
     fi
 }
 


### PR DESCRIPTION
Traefik talks to `nginx` in the `my127ws` namespace.

If two environments are running at once, the `nginx` DNS address is load balanced between the two environments.

Also use a separate namespace for monitoring.