### PR TITLE
Fix npm being unavailable

### DIFF
--- a/docker/image/console/root/bin/app
+++ b/docker/image/console/root/bin/app
@@ -8,6 +8,9 @@ main()
 
 bootstrap()
 {
+    export NVM_DIR="$HOME/.nvm"
+    # shellcheck source=/home/build/nvm.sh
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
     . /lib/sidekick.sh
 }
 

--- a/docker/image/console/root/lib/task/skeleton/apply.sh
+++ b/docker/image/console/root/lib/task/skeleton/apply.sh
@@ -2,10 +2,12 @@
 
 function task_skeleton_apply()
 {
-    if [ "${PHP_VERSION:0:3}" == "5.6" ]; then
-      mv /home/build/skeleton/composer-5.6.json /home/build/skeleton/composer.json
-    else
-      rm -f /home/build/skeleton/composer-5.6.json
+    if [ -f /home/build/skeleton/composer-5.6.json ]; then
+        if [ "${PHP_VERSION:0:3}" == "5.6" ]; then
+            mv /home/build/skeleton/composer-5.6.json /home/build/skeleton/composer.json
+        else
+            rm -f /home/build/skeleton/composer-5.6.json
+        fi
     fi
     run "rsync --exclude='*.twig' --ignore-existing -a /home/build/skeleton/ /app/"
 }


### PR DESCRIPTION
Fixes:
```
[docker(console):/app/public/skin/frontend/rwd/example]:
■ > npm install
bash: npm: command not found
```

Also fix composer-5.6.json being missing erroring the build the second time due to the new volume.