### PR TITLE
Add SQL profiler to local.xml

### DIFF
--- a/skeleton/public/app/etc/local.xml.twig
+++ b/skeleton/public/app/etc/local.xml.twig
@@ -33,6 +33,9 @@
                     <initStatements><![CDATA[SET NAMES utf8]]></initStatements>
                     <type><![CDATA[pdo_mysql]]></type>
                     <password><![CDATA[{{ @('database.pass') }}]]></password>
+                    {% if @('app.mode') == 'development' %}
+                    <profiler><![CDATA[1]]></profiler>
+                    {% endif %}
                 </connection>
             </default_setup>
         </resources>


### PR DESCRIPTION
Allow tooling to read SQL profiles when in `development` mode