### PR TITLE
fix mysql available task

### DIFF
--- a/docker/image/console/root/lib/task/mysql/available.sh
+++ b/docker/image/console/root/lib/task/mysql/available.sh
@@ -12,6 +12,6 @@ function task_mysql_available()
         fi
 
         sleep 1
-        ((counter++))
+        ((++counter))
     done
 }


### PR DESCRIPTION
"((counter++))" syntax results in exit 1 when the result of the expression is 0, pre-incrementing ensures the expression will always be above 0.