### PR TITLE
Set maxmemory and eviction policies for redis

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -115,6 +115,8 @@ services:
       - shared
   redis:
     image: redis:4-alpine
+    # 1GB; evict any least recently used key even if they don't have a TTL
+    command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis
@@ -123,6 +125,8 @@ services:
       - shared
   redis-session:
     image: redis:4-alpine
+    # 1GB; evict key that would expire soonest
+    command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis


### PR DESCRIPTION
* Evicts sessions that would expire soonest (Cm_RedisSession has low TTL for bots, for example).
* Evicts cache entries that have been used least recently, even though magento doesn't set a TTL for full page cache entries.