### PR TITLE
MISC: Bind MySQL port to host

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -111,6 +111,8 @@ services:
       - MYSQL_DATABASE=${DB_NAME}
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
+    ports:
+      - "3306:3306"
     networks:
       - private
       - shared

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -112,7 +112,7 @@ services:
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
     ports:
-      - "3306:3306"
+      - 3306
     networks:
       - private
       - shared

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -90,3 +90,8 @@ command('frontend console'):
   exec: |
     #!bash(harness:/)|@
     docker-compose -p @('namespace') exec -u build console bash -i -c 'cd @('frontend.path'); bash'
+
+command('port <service>'):
+  exec: |
+    #!bash(harness:/)|=
+    docker port $(docker-compose -p ={@('namespace')} ps -q ={input.argument('service')})


### PR DESCRIPTION
Attempt to bind `mysql` container port `3306` to host to allow developers to manipulate the database through GUI tools such as Sequel Pro.

---

Am not sure if this solution is _correct_ going forwards - Assuming this would break should another WS instance create another `mysql` container?

Failing that, is it possible to leverage Traefik to bind a host name and port to the `mysql` container? `mysql.magento-project.my127.site` for example. Have spied similar config here https://github.com/my127/workspace/blob/629aa2f2d158d6bb50458479ea124e100fb6ff29/home/service/logger/docker-compose.yml#L11-L14 (Again am not sue if this is possible)